### PR TITLE
Fix an ImportError on unittest

### DIFF
--- a/pinocchio/spec.py
+++ b/pinocchio/spec.py
@@ -93,7 +93,10 @@ import re
 import types
 import unittest
 from StringIO import StringIO
-from unittest import _WritelnDecorator
+try:
+    from unittest.runner import _WritelnDecorator #python 2.7
+except ImportError:
+    from unittest import _WritelnDecorator
 
 import nose
 from nose.plugins import Plugin


### PR DESCRIPTION
In Python2.7+ the class _WritelnDecorator is inside the package unittest.runner
Taken from https://github.com/gfxmonk/rednose/commit/b50a88698c8c6b5b6d044e68f21b4ea27629d5d8
