### PR TITLE
Fix for spec failing on errors during test suite initialization

### DIFF
--- a/pinocchio/spec.py
+++ b/pinocchio/spec.py
@@ -409,6 +409,8 @@ class Spec(Plugin):
         self.stream.print_context(context)
 
     def _print_spec(self, color, test, status=None):
+        if isinstance(test, nose.suite.ContextSuite):
+            return
         if isinstance(test.test, doctest.DocTestCase) and not self.spec_doctests:
             return
         self.stream.print_spec(self._colorize(color), test, status)


### PR DESCRIPTION
Hi.

I was unfortunate enough to stuck into this stack trace during running our nose test suite with --with-spec enabled:

``` python
Process Process-1:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/local/Cellar/python/2.7.2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "<project root>/src/contacts/contacts/avatars/application.py", line 250, in start_server
    http_server.listen(port)
  File "<project root>/eggs/tornado-1.2.1-py2.7.egg/tornado/httpserver.py", line 156, in listen
    self.start(1)
  File "<project root>/eggs/tornado-1.2.1-py2.7.egg/tornado/httpserver.py", line 229, in start
    ioloop.IOLoop.READ)
  File "<project root>/eggs/tornado-1.2.1-py2.7.egg/tornado/ioloop.py", line 151, in add_handler
    self._impl.register(fd, events | self.ERROR)
  File "<project root>/eggs/tornado-1.2.1-py2.7.egg/tornado/ioloop.py", line 459, in register
    self._control(fd, events, select.KQ_EV_ADD)
  File "<project root>/eggs/tornado-1.2.1-py2.7.egg/tornado/ioloop.py", line 482, in _control
    self._kqueue.control([kevent], 0)
OSError: [Errno 9] Bad file descriptor
<nose.suite.ContextSuite context=tests.test_contacts2.test_avatars>
Traceback (most recent call last):
  File "bin/tests", line 112, in <module>
    nose.main(argv=['nose', '-i', '^(it|ensure|must|should|specs?|examples?|deve)', '-i', '(specs?(.py)?|examples?(.py)?)$', '--nologcapture', '--verbose']+sys.argv[1:])
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/core.py", line 118, in __init__
    **extra_args)
  File "/usr/local/Cellar/python/2.7.2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/main.py", line 95, in __init__
    self.runTests()
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/core.py", line 197, in runTests
    result = self.testRunner.run(self.test)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/core.py", line 61, in run
    test(result)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/suite.py", line 176, in __call__
    return self.run(*arg, **kw)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/suite.py", line 223, in run
    test(orig)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/suite.py", line 176, in __call__
    return self.run(*arg, **kw)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/suite.py", line 223, in run
    test(orig)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/suite.py", line 176, in __call__
    return self.run(*arg, **kw)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/suite.py", line 213, in run
    result.addError(self, self._exc_info())
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/proxy.py", line 134, in addError
    plugins.addError(self.test, err)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/plugins/manager.py", line 94, in __call__
    return self.call(*arg, **kw)
  File "<project root>/eggs/nose-1.1.2-py2.7.egg/nose/plugins/manager.py", line 162, in simple
    result = meth(*arg, **kw)
  File "<project root>/eggs/pinocchio-0.3-py2.7.egg/pinocchio/spec.py", line 396, in addError
    dispatch_on_type(supported_error_types, err[0])
  File "<project root>/eggs/pinocchio-0.3-py2.7.egg/pinocchio/spec.py", line 111, in dispatch_on_type
    return func(instance)
  File "<project root>/eggs/pinocchio-0.3-py2.7.egg/pinocchio/spec.py", line 388, in <lambda>
    return lambda _: self._print_spec(color, test, message)
  File "<project root>/eggs/pinocchio-0.3-py2.7.egg/pinocchio/spec.py", line 413, in _print_spec
    if isinstance(test.test, doctest.DocTestCase) and not self.spec_doctests:
AttributeError: 'ContextSuite' object has no attribute 'test'
```

It appears that any error happening on test suite initialization code in **init**.py (bad practice, but that's how we have it for now) triggers this failure. I think that my very straightforward fix solves this issue. Hope you'll find it worthy enough to merge into upstream and pypi package :)
