### PR TITLE
Make stopwatch work with test methods.

### DIFF
--- a/examples/test_stopwatch.py
+++ b/examples/test_stopwatch.py
@@ -1,4 +1,5 @@
 import time
+import unittest
 
 def test_0sec():
     time.sleep(0)
@@ -14,3 +15,7 @@ def test_2sec():
 
 def nada():
     pass
+
+class MyTestClass(unittest.TestCase):
+    def test_1sec_method(self):
+        time.sleep(1)

--- a/pinocchio/stopwatch.py
+++ b/pinocchio/stopwatch.py
@@ -131,14 +131,7 @@ class Stopwatch(Plugin):
 
     def stopTest(self, test):
         """
-        stopTest: stop timing, canonicalize the test name, and save
-        the run time.
+        stopTest: stop timing, and save the run time.
         """
         runtime = time.time() - self._started
-
-        # CTB: HACK!
-        testname = str(test)
-        if ' ' in testname:
-            testname = testname.split(' ')[1]
-            
-        self.times[testname] = runtime
+        self.times[test.test.id()] = runtime


### PR DESCRIPTION
Prior to this commit, test methods are always run, even if they are
slower than the "--faster-than" threshold.

The problem was, stopTest put the qualified name of the test class in
the dontrun dict, instead of the qualified name of the _method_.

To fix this, we use the id() method of test to get the qualified name,
just as xunit, a built-in plugin to nose, does.
