### PR TITLE
fix encoding errors with io.StringIO in python2

### DIFF
--- a/pinocchio/output_save.py
+++ b/pinocchio/output_save.py
@@ -13,7 +13,11 @@ import logging
 import os
 from nose.plugins.base import Plugin
 
-from io import StringIO as p_StringO
+
+try:
+    from StringIO import StringIO as p_StringO
+except:
+    from io import StringIO as p_StringO
 
 import traceback
 

--- a/pinocchio/spec.py
+++ b/pinocchio/spec.py
@@ -92,8 +92,10 @@ import os
 import re
 import types
 import unittest
-
-from io import StringIO
+try:
+    from StringIO import StringIO
+except:
+    from io import StringIO
 
 try:
     from unittest.runner import _WritelnDecorator #python 2.7


### PR DESCRIPTION
Sorry my last PR introduced a bug in some cases with unicode.
io.StringIO treat output as unicode, in py2 io.StringIO seems to call StringIO.StringIO.getvalue() which raises UnicodeError for char > 128.
