### PR TITLE
[RFC] fix sorting issue with newer nose version

### DIFF
--- a/pinocchio/decorator.py
+++ b/pinocchio/decorator.py
@@ -102,7 +102,7 @@ class Decorator(Plugin):
         wantMethod -- attach matching attributes to this method.
         """
         fullname = '%s.%s.%s' % (method.__module__,
-                                 method.__self__.__class__.__name__,
+                                 method.im_class.__name__,
                                  method.__name__)
 
         self._attach_attributes(fullname, method)


### PR DESCRIPTION
This is just an attempt to fix the issue with newer versions of nose.
Nose plugin manager uses this `sort()` method to sort the plugins : 

``` python
def sort(self):
        return sort_list(self._plugins, lambda x: getattr(x, 'score', 1), reverse=True)
```

So I thought that setting a high score would be enough.

Unfortunately with my changes, tests are not even run... I'll continue to look at it. Do you have any suggestion ?
