### PR TITLE
Use `object.__doc__` instead of `inspect.getdoc()`.

### DIFF
--- a/pinocchio/spec.py
+++ b/pinocchio/spec.py
@@ -89,7 +89,6 @@ cases will be shown in yellow. You need an ANSI terminal to use this.
 """
 
 import doctest
-import inspect
 import os
 import re
 import types
@@ -201,17 +200,17 @@ def testName(object, cleaner=underscored2spec, dflt=None):
         return cleaner(v)
 
 def camelcaseDescription(object):
-    return inspect.getdoc(object) or testName(object, cleaner=camelcase2spec)
+    return object.__doc__ or testName(object, cleaner=camelcase2spec)
 
 def underscoredDescription(object):
-    return inspect.getdoc(object) or testName(object).capitalize()
+    return object.__doc__ or testName(object).capitalize()
 
 def doctestContextDescription(doctest):
     return doctest._dt_test.name
 
 def noseMethodDescription(test):
     method = getattr(test.method, '_func', test.method)
-    return inspect.getdoc(method) or testName(method)
+    return method.__doc__ or testName(method)
 
 def unittestMethodDescription(test):
     testMethod = getattr(test, test._testMethodName)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pinocchio',
-    version="0.4.2",
+    version="0.4.3",
     description = 'pinocchio plugins for the nose testing framework',
     author = 'C. Titus Brown and Michal Kwiatkowski',
     author_email = 'titus@idyll.org,michal@trivas.pl',


### PR DESCRIPTION
Since Python 3.5 `inspect.getdoc()` inherits docstrings from
superclasses, which is not what we want here.

Fixes #29.